### PR TITLE
clarify the effect of tilde character

### DIFF
--- a/README
+++ b/README
@@ -228,7 +228,10 @@ qrz de pa0rct ++test--   In- and decrease speed on the fly in 2 wpm steps.
                          Repeated '+' and '-' characters are allowed,
                          in such cases increase and decrease of speed is
                          multiple of 2 wpm.
-de d~l~2~w~r~j pse k     Add half-space delay after each character
+de ~d~l~2~w~rj pse k     Add half-space delay after characters
+                         NOTE: the delay is added after the character
+                         _following_ the tilde (~). E.g. AB~CD results in
+                         a delay between C and D.
 
 
 Default startup values


### PR DESCRIPTION
Fixed the example and clarified that extra space is added after the next char (i.e. not at the place of the tilde itself).

In fact I'd have liked if ~ could represent the space, just as the normal space char does. Adding it after the next char is counter intuitive, IMO.

